### PR TITLE
Brew doesn't take a `-y` option?

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,7 +54,7 @@
     On macOS (using Homebrew):
 
     #+BEGIN_SRC bash
-    brew install -y opam m4
+    brew install opam m4
     #+END_SRC
 
     Or, if you prefer not to use Homebrew, you can download a binary directly


### PR DESCRIPTION
Are we sure that brew takes `-y`?

On `brew install -y opam m4`, I get `Error: invalid option: -y`
And no results for `brew install --help | rg -- '-y'`