### PR TITLE
Provide more background on hello_world.exe

### DIFF
--- a/README.org
+++ b/README.org
@@ -130,6 +130,8 @@
    dune build hello_world.exe
    dune exec ./hello_world.exe
    #+END_SRC
+   
+   *hello_world.exe is the executible version of the hello_world.ml file.
 
    This should print ~Hello, World~.
 ** Test that expect-tests work as intended


### PR DESCRIPTION
I was a bit confused by the hello_world.exe file as I couldn't find it in the 01-install-ocaml folder. I found this link:

https://dune.build

and was able to interpret hello_world.exe as the executable version of hello_world.ml. I wasn't able to see hello_world.exe as a hidden file in the folder, which was weird. Hopefully this small description helps readers to understand where the .exe file is coming from.